### PR TITLE
Use org.freedesktop.ScreenSaver interface instead of gnome's one

### DIFF
--- a/scripts/screenlock.sh
+++ b/scripts/screenlock.sh
@@ -41,7 +41,7 @@ case "${com}" in
     ;;
 
 "state")
-    dbus-send --print-reply --session --type=method_call --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.GetActive | tail -n 1 | grep -Eo '[^ ]*$'
+    dbus-send --print-reply --session --type=method_call --dest=org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.GetActive | tail -n 1 | grep -Eo '[^ ]*$'
     ;;
 
 *)

--- a/scripts/screenlock.sh
+++ b/scripts/screenlock.sh
@@ -41,9 +41,15 @@ case "${com}" in
     ;;
 
 "state")
-    dbus-send --print-reply --session --type=method_call --dest=org.freedesktop.ScreenSaver /ScreenSaver org.freedesktop.ScreenSaver.GetActive | tail -n 1 | grep -Eo '[^ ]*$'
+    case "$XDG_CURRENT_DESKTOP" in
+    "GNOME")
+        dbus-send --print-reply --session --type=method_call --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.GetActive | tail -n 1 | grep -Eo '[^ ]*$'
+        ;;
+    "KDE")
+        dbus-send --print-reply --session --type=method_call --dest=org.kde.screensaver /ScreenSaver org.freedesktop.ScreenSaver.GetActive | tail -n 1 | grep -Eo '[^ ]*$'
+        ;;
+    esac
     ;;
-
 *)
     __error
     ;;


### PR DESCRIPTION
Now it should work on most Linux desktop environments and not only on Gnome. Tested on KDE.