### PR TITLE
fix: Try retaining most messages and use QoS 2.

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -14,8 +14,8 @@ type LogLevels struct {
 }
 
 var (
-	Retain           bool          = false
-	QoS              byte          = 0
+	Retain           bool          = true
+	QoS              byte          = 2
 	HADiscoveryDelay time.Duration = 500 * time.Millisecond
 	MachineID        string
 	LogState         = LogLevels{


### PR DESCRIPTION
I've been testing this, and reliability seems good, but I do have concerns about whether retaining certain topics could be problematic.

Specifically, prior to these changes, I had issues with Home Assistant losing track of ha-mqtt-iot and no longer receiving updates, even though ha-mqtt-iot was sending value updates correctly. My suspicion is Availability topics being lost.